### PR TITLE
Fix VSIX output path in CI and release workflows

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -34,7 +34,7 @@ jobs:
     env:
       VsixManifestPath: visual-studio\Manifests\VS${{ matrix.VsTargetVersion }}\source.extension.vsixmanifest
       VsTargetVersion: 'VS${{ matrix.VsTargetVersion }}'
-      VsixPath: visual-studio\ProtoAttributor\bin\VS${{ matrix.VsTargetVersion }}\Release\ProtoAttributor${{ matrix.VsTargetVersion }}.vsix
+      VsixPath: visual-studio\ProtoAttributor\bin\Release\ProtoAttributor${{ matrix.VsTargetVersion }}.vsix
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
     env:
       VsixManifestPath: visual-studio\Manifests\VS${{ matrix.VsTargetVersion }}\source.extension.vsixmanifest
       VsTargetVersion: 'VS${{ matrix.VsTargetVersion }}'
-      VsixPath: visual-studio\ProtoAttributor\bin\VS${{ matrix.VsTargetVersion }}\Release\ProtoAttributor${{ matrix.VsTargetVersion }}.vsix
+      VsixPath: visual-studio\ProtoAttributor\bin\Release\ProtoAttributor${{ matrix.VsTargetVersion }}.vsix
       BaseVersion: '1.2.0.0'
 
     steps:


### PR DESCRIPTION
Actual MSBuild output is bin\Release\ProtoAttributor2022.vsix not bin\VS2022\Release\ProtoAttributor2022.vsix. Remove the spurious VS{version} subdirectory from VsixPath in both workflows.